### PR TITLE
Add option file to carbone-cli and update carbone version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ where
 - [input-file] is a docx template
 - [data-file] is a json file
 - [output-file] is the result docx document
+- [options] is a json file that contains optional parameters [read more](https://github.com/Ideolys/carbone/#user-content-api-reference)
 
-e.g, 
+e.g,
 
 ```bash
 carbone-cli template.docx data.json output.docx
@@ -23,5 +24,12 @@ carbone-cli template.docx data.json output.docx
 
 will generate `output.docx` from `template.docx` and `data.json`
 
+or with options file:
+
+```bash
+carbone-cli template.docx data.json output.pdf options.json
+```
+
+will generate `output.docx` from `template.docx` and `data.json` depending on `options.json`.
 
 

--- a/bin/carbone-cli
+++ b/bin/carbone-cli
@@ -3,32 +3,45 @@
 const fs = require('fs');
 const carbone = require('carbone');
 
-function usage () {
-  console.info('Usage: carbone-cli [input-file] [data-file] [output-file]');
+const printUsage = () => {
+  console.info('Usage: carbone-cli [input-file] [data-file] [output-file] [options]');
   console.info('  [input-file]\t\tTemplate in docx format');
   console.info('  [data-file]\t\tData file in json format');
   console.info('  [output-file]\t\tOutput file in docx format');
+  console.info('  [options-file]\t\tOptional render parameters');
 }
 
-if (process.argv.length != 5) {
-  usage();
+const getFile = file => {
+  const res = fs.readFileSync(file, "utf-8");
+  return JSON.parse(res);
+}
+
+if (process.argv.length < 5) {
+  printUsage();
   process.exit();
 }
 
 const inputFile = process.argv[2]
 const dataFile = process.argv[3]
 const outputFile = process.argv[4]
+const optionsFile = process.argv[5]
 
 console.log(inputFile);
 console.log(dataFile);
 console.log(outputFile);
 
-const res = fs.readFileSync(dataFile, "utf-8");
-const data = JSON.parse(res);
+const data = getFile(dataFile);
 
-carbone.render(inputFile, data, function (err, result) {
+let options = {};
+if (optionsFile) {
+  console.log(optionsFile);
+  options = getFile(optionsFile);
+}
+
+carbone.render(inputFile, data, options, async (err, result) => {
   if (err) {
     return console.log(err);
   }
-  fs.writeFileSync(outputFile, result);
+  await fs.writeFileSync(outputFile, result);
+  process.exit();
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "author": "Nguyen Duc Tam <tamnguyen@anduintransact.com>",
   "license": "MIT",
   "dependencies": {
-    "carbone": "^1.1.0"
+    "carbone": "^1.2.1"
   }
 }


### PR DESCRIPTION
This change add support for an optional object to configure the render (cf [Carbone Options](https://github.com/Ideolys/carbone/#user-content-rendertemplatepath-data-options-callback)).
The optional Object is passing through a json file as last arg, example:
```bash
carbone-cli template.docx data.json output.pdf options.json
```
It's not mandatory to pass the last option file as arg to make it work.
Also the dependancy Carbone has been updated.
